### PR TITLE
Make Openstack error more readable

### DIFF
--- a/lib/vagrant-openstack/action/boot.rb
+++ b/lib/vagrant-openstack/action/boot.rb
@@ -73,7 +73,12 @@ module VagrantPlugins
             ])
           end
           # Create the server
-          server = env[:os_connection].servers.create(options)
+          begin
+              server = env[:os_connection].servers.create(options)
+          rescue Excon::Errors::BadRequest => e
+              message = JSON.parse(e.response.body)["badRequest"]["message"]
+              raise Excon::Errors::BadRequest, "Error creating server, Openstack returned message: #{message}" 
+          end
 
           # Store the ID right away so we can track it
           env[:machine].id = server.id


### PR DESCRIPTION
Currently the error message returned by Openstack is hidden inside the body of the returned response. This patch makes the error much more visible to the user
